### PR TITLE
Update config file location and improve comments for clarity

### DIFF
--- a/setup/eilin/config.ghostty
+++ b/setup/eilin/config.ghostty
@@ -1,10 +1,13 @@
-# Sophia · Ghostty config
+# eilin · ghostty config
 #
-# Location: ~/.config/ghostty/config.toml
+# Location: ~/Library/Application Support/com.mitchellh.ghostty/config.ghostty
 
 # ---------- Font ----------
 
-font-family = JetBrainsMono Nerd Font Mono
+# JetBrainsMono Nerd Font
+# FiraCode Nerd Font
+# FiraMono Nerd Font
+font-family = MesloLGS Nerd Font
 font-size = 13
 
 # 稍微加粗字体笔画，仅 macOS
@@ -30,6 +33,9 @@ window-height = 48
 # 窗口内边距，单位为 point
 window-padding-x = 8
 window-padding-y = 6
+
+# 均衡 Cell 无法整除产生的额外边缘空间
+window-padding-balance = true
 
 # 不恢复上一次的窗口、Tab 和 Split 状态
 window-save-state = never

--- a/setup/eilin/config.ghostty
+++ b/setup/eilin/config.ghostty
@@ -4,9 +4,7 @@
 
 # ---------- Font ----------
 
-# JetBrainsMono Nerd Font
-# FiraCode Nerd Font
-# FiraMono Nerd Font
+# JetBrainsMono Nerd Font, FiraCode Nerd Font, FiraMono Nerd Font
 font-family = MesloLGS Nerd Font
 font-size = 13
 

--- a/setup/eilin/zshrc.private
+++ b/setup/eilin/zshrc.private
@@ -20,7 +20,11 @@ export ANTHROPIC_BASE_URL="https://new-api.iohubonline.club"
 export ANTHROPIC_AUTH_TOKEN="<YOUR_ANTHROPIC_AUTH_TOKEN>"
 
 # Claude Code 默认模型
-export ANTHROPIC_MODEL="claude-opus-4-8-thinking"
+# export ANTHROPIC_MODEL="claude-opus-4-8-thinking"
+export ANTHROPIC_MODEL="claude-fable-5"
+
+# 不发送实验性 anthropic-beta header (new-api/Bedrock 代理不支持，后端要求开启此开关)
+export CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS="1"
 
 # Claude Code 推理强度
 export CLAUDE_CODE_EFFORT_LEVEL="xhigh"

--- a/setup/sophia/config.ghostty
+++ b/setup/sophia/config.ghostty
@@ -1,11 +1,11 @@
 # sophia · ghostty config
 #
-# Location: ~/.config/ghostty/config.toml
+# Location: ~/.config/ghostty/config.ghostty
 
 # ---------- Font ----------
 
-# MesloLGS Nerd Font
-font-family = JetBrainsMono Nerd Font Mono
+# JetBrainsMono Nerd Font, FiraCode Nerd Font, FiraMono Nerd Font
+font-family = MesloLGS Nerd Font
 font-size = 13
 
 # 稍微加粗字体笔画，仅 macOS
@@ -31,6 +31,9 @@ window-height = 48
 # 窗口内边距，单位为 point
 window-padding-x = 8
 window-padding-y = 6
+
+# 均衡 Cell 无法整除产生的额外边缘空间
+window-padding-balance = true
 
 # 不恢复上一次的窗口、Tab 和 Split 状态
 window-save-state = never

--- a/tools/cli/summarize.md
+++ b/tools/cli/summarize.md
@@ -11,6 +11,22 @@ Config lives at `~/.summarize/config.json`, inspect with `summarize status`.
 
 When no API keys are configured, auto mode falls back to installed coding CLIs (claude, gemini, codex, copilot, ...).
 
+My current config (API key redacted):
+
+```json
+{
+  "env": {
+    "OPENROUTER_API_KEY": "<YOUR_OPENROUTER_API_KEY>"
+  },
+  "model": "openrouter/z-ai/glm-5.2",
+  "output": {
+    "language": "auto",
+    "length": "xxl"
+  },
+  "prompt": "中文回复，专业术语保持英文原文。严格基于原文，不要编造细节。"
+}
+```
+
 ### Chrome Extension
 
 Prompt override (my current config):


### PR DESCRIPTION
This pull request updates terminal and shell configuration files for the `eilin` and `sophia` environments, as well as documentation for the CLI summarize tool. The main changes include switching default fonts, improving window padding settings, updating Anthropic model environment variables, and providing an example configuration for the summarize CLI.

**Terminal configuration updates:**

* Changed the default font in both `setup/eilin/config.ghostty` and `setup/sophia/config.ghostty` to `MesloLGS Nerd Font`, updated font comments, and corrected the config file location comments. [[1]](diffhunk://#diff-1207d70f64f891ed1ddd9d2812c26c94615066a1901b5698657a57256e16dcaaL1-R10) [[2]](diffhunk://#diff-4b5f46eaa7fc6138c65441a35f6436effff9084db2279fe6569a780aff2f9839L3-R8)
* Added `window-padding-balance = true` to both Ghostty config files to handle extra edge space when cell sizes do not divide evenly. [[1]](diffhunk://#diff-1207d70f64f891ed1ddd9d2812c26c94615066a1901b5698657a57256e16dcaaR37-R39) [[2]](diffhunk://#diff-4b5f46eaa7fc6138c65441a35f6436effff9084db2279fe6569a780aff2f9839R35-R37)

**Shell environment variable updates:**

* Changed the default Anthropic model to `claude-fable-5` in `setup/eilin/zshrc.private`, commented out the previous model, and added an environment variable to disable experimental beta headers for compatibility with the new API.

**Documentation improvements:**

* Added a sample JSON configuration block to `tools/cli/summarize.md` to illustrate a typical summarize CLI config, including model, API key, and prompt settings.